### PR TITLE
anchor generation

### DIFF
--- a/src/html.zig
+++ b/src/html.zig
@@ -8,24 +8,37 @@ const nodes = @import("nodes.zig");
 const strings = @import("strings.zig");
 const scanners = @import("scanners.zig");
 
-pub fn print(allocator: *mem.Allocator, options: *Options, root: *nodes.AstNode) ![]u8 {
-    var buffer = std.ArrayList(u8).init(allocator);
-
-    var formatter = HtmlFormatter{
-        .allocator = allocator,
-        .options = options,
-        .buffer = &buffer,
-    };
+pub fn print(allocator: *mem.Allocator, options: Options, root: *nodes.AstNode) ![]u8 {
+    var formatter = HtmlFormatter.init(allocator, options);
+    defer formatter.deinit();
 
     try formatter.format(root, false);
-    return buffer.toOwnedSlice();
+
+    return formatter.buffer.toOwnedSlice();
 }
 
 const HtmlFormatter = struct {
     allocator: *mem.Allocator,
-    options: *Options,
-    buffer: *std.ArrayList(u8),
+    options: Options,
+    buffer: std.ArrayList(u8),
     last_was_lf: bool = true,
+    anchor_map: std.StringHashMap(void),
+
+    pub fn init(allocator: *mem.Allocator, options: Options) HtmlFormatter {
+        return .{
+            .allocator = allocator,
+            .options = options,
+            .buffer = std.ArrayList(u8).init(allocator),
+            .anchor_map = std.StringHashMap(void).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *HtmlFormatter) void {
+        for (self.anchor_map.items()) |entry| {
+            self.allocator.free(entry.key);
+        }
+        self.anchor_map.deinit();
+    }
 
     const NEEDS_ESCAPED = strings.createMap("\"&<>");
     const HREF_SAFE = strings.createMap("-_.+!*'(),%#@?=;:/,+&$~abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
@@ -182,6 +195,16 @@ const HtmlFormatter = struct {
                 if (entering) {
                     try self.cr();
                     try std.fmt.format(Writer{ .formatter = self }, "<h{}>", .{nch.level});
+                    if (self.options.render.header_anchors) {
+                        var text_content = try self.collectText(node);
+                        defer self.allocator.free(text_content);
+                        var id = try self.anchorize(text_content);
+                        try self.writeAll("<a href=\"#");
+                        try self.writeAll(id);
+                        try self.writeAll("\" id=\"");
+                        try self.writeAll(id);
+                        try self.writeAll("\"></a>");
+                    }
                 } else {
                     try std.fmt.format(Writer{ .formatter = self }, "</h{}>\n", .{nch.level});
                 }
@@ -391,6 +414,59 @@ const HtmlFormatter = struct {
         return false;
     }
 
+    fn collectText(self: *HtmlFormatter, node: *nodes.AstNode) ![]u8 {
+        var out = std.ArrayList(u8).init(self.allocator);
+        try collectTextInto(&out, node);
+        return out.toOwnedSlice();
+    }
+
+    fn collectTextInto(out: *std.ArrayList(u8), node: *nodes.AstNode) mem.Allocator.Error!void {
+        switch (node.data.value) {
+            .Text, .Code => |literal| {
+                try out.appendSlice(literal);
+            },
+            .LineBreak, .SoftBreak => try out.append(' '),
+            else => {
+                var it = node.first_child;
+                while (it) |child| {
+                    try collectTextInto(out, child);
+                    it = child.next;
+                }
+            },
+        }
+    }
+
+    fn anchorize(self: *HtmlFormatter, header: []const u8) ![]const u8 {
+        // TODO: unicode tolower
+        var lower = try std.ascii.allocLowerString(self.allocator, header);
+        defer self.allocator.free(lower);
+        var removed = try scanners.removeAnchorizeRejectedChars(self.allocator, lower);
+        defer self.allocator.free(removed);
+
+        for (removed) |*c| {
+            if (c.* == ' ') c.* = '-';
+        }
+
+        var uniq: usize = 0;
+        while (true) {
+            var anchor = if (uniq == 0)
+                try self.allocator.dupe(u8, removed)
+            else
+                try std.fmt.allocPrint(self.allocator, "{}-{}", .{ removed, uniq });
+            errdefer self.allocator.free(anchor);
+
+            var getPut = try self.anchor_map.getOrPut(anchor);
+            if (!getPut.found_existing) {
+                // anchor now belongs in anchor_map.
+                return anchor;
+            }
+
+            self.allocator.free(anchor);
+
+            uniq += 1;
+        }
+    }
+
     const TAGFILTER_BLACKLIST = [_][]const u8{
         "title",
         "textarea",
@@ -445,33 +521,11 @@ const HtmlFormatter = struct {
     }
 };
 
-const TestParts = struct {
-    allocator: std.heap.GeneralPurposeAllocator(.{}) = undefined,
-    options: Options = .{},
-    buffer: std.ArrayList(u8) = undefined,
-    formatter: HtmlFormatter = undefined,
-
-    fn init(self: *TestParts) void {
-        self.allocator = std.heap.GeneralPurposeAllocator(.{}){};
-        self.buffer = std.ArrayList(u8).init(&self.allocator.allocator);
-        self.formatter = HtmlFormatter{
-            .allocator = &self.allocator.allocator,
-            .options = &self.options,
-            .buffer = &self.buffer,
-        };
-    }
-
-    fn deinit(self: *TestParts) void {
-        self.buffer.deinit();
-        _ = self.allocator.deinit();
-    }
-};
-
 test "escaping works as expected" {
-    var testParts = TestParts{};
-    testParts.init();
-    defer testParts.deinit();
+    var formatter = HtmlFormatter.init(std.testing.allocator, .{});
+    defer formatter.deinit();
 
-    try testParts.formatter.escape("<hello & goodbye>");
-    std.testing.expectEqualStrings("&lt;hello &amp; goodbye&gt;", testParts.buffer.items);
+    try formatter.escape("<hello & goodbye>");
+    std.testing.expectEqualStrings("&lt;hello &amp; goodbye&gt;", formatter.buffer.items);
+    formatter.buffer.deinit();
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,15 +9,16 @@ const nodes = @import("nodes.zig");
 const html = @import("html.zig");
 
 pub fn main() !void {
-    @setEvalBranchQuota(1500);
+    @setEvalBranchQuota(2000);
 
     var stderr = std.io.getStdErr().writer();
 
     const params = comptime [_]clap.Param(clap.Help){
         try clap.parseParam("-h, --help                       Display this help and exit"),
         try clap.parseParam("-u, --unsafe                     Render raw HTML and dangerous URLs"),
-        try clap.parseParam("-e, --extension <EXTENSION>...   Enable an extension. (" ++ extensionsFriendly ++ ")"),
-        try clap.parseParam("    --smart                      Use smart punctuation."),
+        try clap.parseParam("-e, --extension <EXTENSION>...   Enable an extension (" ++ extensionsFriendly ++ ")"),
+        try clap.parseParam("    --header-anchors             Generate anchors for headers"),
+        try clap.parseParam("    --smart                      Use smart punctuation"),
     };
 
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -39,6 +40,8 @@ pub fn main() !void {
         options.render.unsafe = true;
     if (args.flag("--smart"))
         options.parse.smart = true;
+    if (args.flag("--header-anchors"))
+        options.render.header_anchors = true;
 
     for (args.options("--extension")) |extension|
         try enableExtension(extension, &options);
@@ -101,7 +104,7 @@ fn markdownToHtmlInternal(resultAllocator: *std.mem.Allocator, internalAllocator
     } else |err| {}
     doc.validate(noisy);
 
-    return try html.print(resultAllocator, &p.options, doc);
+    return try html.print(resultAllocator, p.options, doc);
 }
 
 pub fn markdownToHtml(allocator: *std.mem.Allocator, options: Options, markdown: []const u8) ![]u8 {

--- a/src/options.zig
+++ b/src/options.zig
@@ -11,6 +11,7 @@ pub const Options = struct {
     pub const Render = struct {
         hard_breaks: bool = false,
         unsafe: bool = false,
+        header_anchors: bool = false,
     };
 
     extensions: Extensions = .{},

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -1152,3 +1152,24 @@ test "autolink" {
     try expectMarkdownHTML(.{ .extensions = .{ .autolink = true } }, "http://commonmark.org\n", "<p><a href=\"http://commonmark.org\">http://commonmark.org</a></p>\n");
     try expectMarkdownHTML(.{ .extensions = .{ .autolink = true } }, "foo@bar.baz\n", "<p><a href=\"mailto:foo@bar.baz\">foo@bar.baz</a></p>\n");
 }
+test "header anchors" {
+    try expectMarkdownHTML(.{ .render = .{ .header_anchors = true } },
+        \\# Hi.
+        \\## Hi 1.
+        \\### Hi.
+        \\#### Hello.
+        \\##### Hi.
+        \\###### Hello.
+        \\# Isn't it grand?
+        \\
+    ,
+        \\<h1><a href="#hi" id="hi"></a>Hi.</h1>
+        \\<h2><a href="#hi-1" id="hi-1"></a>Hi 1.</h2>
+        \\<h3><a href="#hi-2" id="hi-2"></a>Hi.</h3>
+        \\<h4><a href="#hello" id="hello"></a>Hello.</h4>
+        \\<h5><a href="#hi-3" id="hi-3"></a>Hi.</h5>
+        \\<h6><a href="#hello-1" id="hello-1"></a>Hello.</h6>
+        \\<h1><a href="#isnt-it-grand" id="isnt-it-grand"></a>Isn't it grand?</h1>
+        \\
+    );
+}


### PR DESCRIPTION
Add anchor generation.

@masterq32 How does this look to you? It vaguely emulates what Comrak did, which in turn is based on GitHub's behaviour, but we don't need to be beholden to any of that as it doesn't fall under spec. Would it be more helpful to just generate the `id` on the header tags themselves?

Sample:

https://github.com/kivikakk/koino/blob/fc89e09f8a8c524228ace34b75d81b5f396e4923/src/parser.zig#L1155-L1175