### PR TITLE
Improves anchoring

### DIFF
--- a/src/html.zig
+++ b/src/html.zig
@@ -198,7 +198,9 @@ fn HtmlFormatter(comptime Writer: type) type {
                             try self.writeAll(id);
                             try self.writeAll("\" id=\"");
                             try self.writeAll(id);
-                            try self.writeAll("\"></a>");
+                            try self.writeAll("\">");
+                            try self.writeAll(self.options.render.anchor_icon);
+                            try self.writeAll("</a>");
                         }
                     } else {
                         try self.writer.print("</h{}>\n", .{nch.level});

--- a/src/html.zig
+++ b/src/html.zig
@@ -14,11 +14,11 @@ pub fn print(writer: anytype, allocator: *std.mem.Allocator, options: Options, r
     try formatter.format(root, false);
 }
 
-fn makeHtmlFormatter(writer: anytype, allocator: *std.mem.Allocator, options: Options) HtmlFormatter(@TypeOf(writer)) {
+pub fn makeHtmlFormatter(writer: anytype, allocator: *std.mem.Allocator, options: Options) HtmlFormatter(@TypeOf(writer)) {
     return HtmlFormatter(@TypeOf(writer)).init(writer, allocator, options);
 }
 
-fn HtmlFormatter(comptime Writer: type) type {
+pub fn HtmlFormatter(comptime Writer: type) type {
     return struct {
         writer: Writer,
         allocator: *std.mem.Allocator,

--- a/src/options.zig
+++ b/src/options.zig
@@ -12,6 +12,8 @@ pub const Options = struct {
         hard_breaks: bool = false,
         unsafe: bool = false,
         header_anchors: bool = false,
+        /// when anchors are enabled, render this icon in front of each heading so people can click it
+        anchor_icon: []const u8 = "",
     };
 
     extensions: Extensions = .{},


### PR DESCRIPTION
Adds option to render heading anchor, also provides the user the freedom of rendering a document in parts by making HtmlRenderer public