### PR TITLE
Change path to search binary in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 spec:
 	zig build
 	temp_file=$$(mktemp); \
-	(cd vendor/cmark-gfm/test && python3 spec_tests.py --program=../../../zig-cache/bin/koino 2>&1) | tee $$temp_file; \
+	(cd vendor/cmark-gfm/test && python3 spec_tests.py --program=../../../zig-out/bin/koino 2>&1) | tee $$temp_file; \
 	printf "::set-output name=specs-succeeded::"; tail -n 1 $$temp_file | perl -pne '/(\d+) passed, (\d+) failed, (\d+) errored, (\d+) skipped/; $$_ = $$1'; \
 	printf "\n::set-output name=spec-count::"; tail -n 1 $$temp_file | perl -pne '/(\d+) passed, (\d+) failed, (\d+) errored, (\d+) skipped/; $$_ = $$1 + $$2 + $$3 + $$4'; \
 	printf "\n::set-output name=conclusion::"; tail -n 1 $$temp_file | perl -pne '/(\d+) passed, (\d+) failed, (\d+) errored, (\d+) skipped/; $$_ = ($$2 + $$3 > 0) ? "failure" : "success"'; \


### PR DESCRIPTION
Change the path to search for the koino binary in (the directory used to store binaries generated by zig in changed from zig-cache to zig-out https://github.com/ziglang/zig/commit/5079d11b213a02e9d9465f3371d0833021cfc636)