### PR TITLE
Zig 0.11.0-dev.1253+fcee1bf99

### DIFF
--- a/src/html.zig
+++ b/src/html.zig
@@ -216,7 +216,7 @@ pub fn HtmlFormatter(comptime Writer: type) type {
                             try self.writeAll("<pre><code>");
                         } else {
                             var first_tag: usize = 0;
-                            while (first_tag < ncb.info.?.len and !ascii.isSpace(ncb.info.?[first_tag]))
+                            while (first_tag < ncb.info.?.len and !ascii.isWhitespace(ncb.info.?[first_tag]))
                                 first_tag += 1;
 
                             try self.writeAll("<pre><code class=\"language-");
@@ -503,7 +503,7 @@ pub fn HtmlFormatter(comptime Writer: type) type {
             for (TAGFILTER_BLACKLIST) |t| {
                 const j = i + t.len;
                 if (literal.len > j and std.ascii.eqlIgnoreCase(t, literal[i..j])) {
-                    return ascii.isSpace(literal[j]) or
+                    return ascii.isWhitespace(literal[j]) or
                         literal[j] == '>' or
                         (literal[j] == '/' and literal.len >= j + 2 and literal[j + 1] == '>');
                 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -56,7 +56,7 @@ pub fn main() !void {
         var arr = std.ArrayList(u8).init(allocator);
         errdefer arr.deinit();
         try html.print(arr.writer(), allocator, options, doc);
-        break :blk arr.toOwnedSlice();
+        break :blk try arr.toOwnedSlice();
     };
     defer allocator.free(output);
 

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -906,7 +906,7 @@ pub const Parser = struct {
 
         if (c == '*' or c == '-' or c == '+') {
             pos += 1;
-            if (!ascii.isSpace(line[pos])) {
+            if (!ascii.isWhitespace(line[pos])) {
                 return false;
             }
 
@@ -952,7 +952,7 @@ pub const Parser = struct {
 
             pos += 1;
 
-            if (!ascii.isSpace(line[pos])) {
+            if (!ascii.isWhitespace(line[pos])) {
                 return false;
             }
 

--- a/src/strings.zig
+++ b/src/strings.zig
@@ -223,6 +223,13 @@ test "removeTrailingBlankLines" {
     }
 }
 
+pub fn isPunct(char: u8) bool {
+    return switch (char) {
+        '!', '\"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~' => true,
+        else => false,
+    };
+}
+
 fn encodeUtf8Into(in_cp: u21, al: *std.ArrayList(u8)) !void {
     // utf8Encode throws:
     // - Utf8CannotEncodeSurrogateHalf, which we guard against that by
@@ -257,7 +264,7 @@ pub fn unescapeInto(text: []const u8, out: *std.ArrayList(u8)) !?usize {
                 break :block i - 1;
             } else if (text[1] == 'x' or text[1] == 'X') {
                 i = 2;
-                while (i < text.len and ascii.isXDigit(text[i])) {
+                while (i < text.len and ascii.isHex(text[i])) {
                     codepoint = (codepoint * 16) + (@as(u32, text[i]) | 32) % 39 - 9;
                     codepoint = std.math.min(codepoint, 0x11_0000);
                     i += 1;
@@ -374,7 +381,7 @@ fn unescape(allocator: mem.Allocator, s: []const u8) ![]u8 {
     var r: usize = 0;
 
     while (r < s.len) : (r += 1) {
-        if (s[r] == '\\' and r + 1 < s.len and ascii.isPunct(s[r + 1]))
+        if (s[r] == '\\' and r + 1 < s.len and isPunct(s[r + 1]))
             r += 1;
         try buffer.append(s[r]);
     }

--- a/src/table.zig
+++ b/src/table.zig
@@ -20,7 +20,7 @@ pub fn freeNested(allocator: std.mem.Allocator, v: [][]u8) void {
 fn row(allocator: std.mem.Allocator, line: []const u8) !?[][]u8 {
     const len = line.len;
     var v = std.ArrayList([]u8).init(allocator);
-    errdefer freeNested(allocator, v.toOwnedSlice());
+    errdefer freeNested(allocator, v.toOwnedSlice() catch unreachable);
     var offset: usize = 0;
 
     if (len > 0 and line[0] == '|')
@@ -33,7 +33,7 @@ fn row(allocator: std.mem.Allocator, line: []const u8) !?[][]u8 {
         if (cell_matched > 0 or pipe_matched > 0) {
             var cell = try unescapePipes(allocator, line[offset .. offset + cell_matched]);
             strings.trimIt(&cell);
-            try v.append(cell.toOwnedSlice());
+            try v.append(try cell.toOwnedSlice());
         }
 
         offset += cell_matched + pipe_matched;
@@ -49,10 +49,10 @@ fn row(allocator: std.mem.Allocator, line: []const u8) !?[][]u8 {
     }
 
     if (offset != len or v.items.len == 0) {
-        freeNested(allocator, v.toOwnedSlice());
+        freeNested(allocator, try v.toOwnedSlice());
         return null;
     } else {
-        return v.toOwnedSlice();
+        return try v.toOwnedSlice();
     }
 }
 


### PR DESCRIPTION
Hi,
I've done the work to make koino build on 0.11.0-dev.1253+fcee1bf99. 
All 51 test passed.

Changes:
- `std.mem.Allocator.shrink` was removed
- `isSpace`, `isAlpha`, `isAlNum` in `ascii` were renamed
- `ascii.isPunct` was removed
I wrote an implementation and placed it (somewhat carelessly) in `strings.zig`
- `ArrayList.toOwnedSlice` now returns an error union
Now there is a case in `tables.zig` where I wasn't able to use `try` - I don't know what to do so I simply bail out.
- `zig-clap` got updated

Thank you,
JVF